### PR TITLE
fix: resolve duplicate React key warnings in VideoFeed

### DIFF
--- a/src/components/VideoFeed.test.tsx
+++ b/src/components/VideoFeed.test.tsx
@@ -12,6 +12,25 @@ vi.mock('@/hooks/useNostr', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    user: {
+      pubkey: 'test-pubkey',
+      signer: {},
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useFollowing', () => ({
+  useFollowing: () => ({
+    data: {
+      pubkeys: ['pubkey1', 'pubkey2'],
+      count: 2,
+    },
+    isLoading: false,
+  }),
+}));
+
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal() as typeof import('@tanstack/react-query');
   return {


### PR DESCRIPTION
- Add event deduplication using Map to prevent duplicate event IDs
- Change key strategy from event.id to `${event.id}-${index}` for uniqueness
- Ensure only latest version of each event is kept when duplicates exist
- Eliminates React warnings about non-unique keys in video feed rendering

Fixes console warnings:
- 'Encountered two children with the same key' React warnings
- Improves component identity management and prevents rendering issues